### PR TITLE
Blast octave

### DIFF
--- a/Singularity.bionic
+++ b/Singularity.bionic
@@ -19,7 +19,8 @@ Version 1.1.0
 	echo "Running post.sh"
 	apt-get -q -y update
 	apt-get -yq install bsdutils lsb-base mysql-client-5.7 mysql-common mysql-server-core-5.7 passwd perl psmisc debconf libc6 libevent-core-2.1-6 libgcc1 liblz4-1 libstdc++6 zlib1g gfortran
-	apt-get -q -y install build-essential less vim wget python-pip libfuse2 r-base openjdk-8-jdk libidn11-dev libssl1.0-dev libssl1.0.0 git ncbi-blast+ octave octave-dataframe
+	apt-get -q -y install build-essential less vim wget python-pip libfuse2 r-base openjdk-8-jdk libidn11-dev libssl1.0-dev libssl1.0.0 git ncbi-blast+ octave
+	update-java-alternatives -s java-1.8.0-openjdk-amd64
 
 	## Trying different mysql install method
 	apt-get download mysql-server-5.7

--- a/Singularity.bionic
+++ b/Singularity.bionic
@@ -19,7 +19,7 @@ Version 1.1.0
 	echo "Running post.sh"
 	apt-get -q -y update
 	apt-get -yq install bsdutils lsb-base mysql-client-5.7 mysql-common mysql-server-core-5.7 passwd perl psmisc debconf libc6 libevent-core-2.1-6 libgcc1 liblz4-1 libstdc++6 zlib1g gfortran
-	apt-get -q -y install build-essential less vim wget python-pip libfuse2 r-base openjdk-8-jdk libidn11-dev libssl1.0-dev libssl1.0.0 git
+	apt-get -q -y install build-essential less vim wget python-pip libfuse2 r-base openjdk-8-jdk libidn11-dev libssl1.0-dev libssl1.0.0 git ncbi-blast+ octave octave-dataframe
 
 	## Trying different mysql install method
 	apt-get download mysql-server-5.7
@@ -29,6 +29,7 @@ Version 1.1.0
 	dpkg --configure mysql-server-5.7
 	apt-get install -yfq mysql-server-5.7
 	apt-get -yq install libmysqld-dev mysql-client libmysqlclient-dev
+	apt-get clean
 
 	R -e 'install.packages(c("data.table","futile.logger","ontologyIndex","yaml"), repos="https://mirror.las.iastate.edu/CRAN/", Ncpus=4, INSTALL_opts="--no-html")'
 


### PR DESCRIPTION
Add blast+ 2.6.0 to the base image to (eventually) replace the two copies that are bundled in GOMAP-data that is irsync'ed from the CyVerse data store.

Add GNU Octave to replace Matlab for FANN-GO.